### PR TITLE
#159 feat: add GetAzUnwrapState and SetAzUnwrapState service definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ set(srv_files
   "srv/ObservationMode.srv"
   "srv/ScanBlockCommand.srv"
   "srv/SetSpectralRecordingGate.srv"
+  "srv/GetAzUnwrapState.srv"
+  "srv/SetAzUnwrapState.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/srv/GetAzUnwrapState.srv
+++ b/srv/GetAzUnwrapState.srv
@@ -1,0 +1,19 @@
+# Return Az absolute-encoder unwrap runtime state from encoder_readout.
+# This avoids reading a local ~/.necst file on the wrong PC/container.
+
+---
+bool success
+string state
+string reason
+string state_path
+bool enabled
+bool valid
+float64 raw_az_deg
+float64 modulo_az_deg
+float64 continuous_az_deg
+int32 branch
+float64 period_deg
+float64 drive_min_deg
+float64 drive_max_deg
+float64 state_age_sec
+float64 persist_age_sec

--- a/srv/SetAzUnwrapState.srv
+++ b/srv/SetAzUnwrapState.srv
@@ -1,0 +1,24 @@
+# Request encoder_readout to initialize the Az absolute-encoder unwrap state.
+# The service is intentionally served by the encoder node so the JSON state is
+# written to the state_path that the encoder node actually reads.
+
+bool use_raw_az
+float64 raw_az_deg
+bool use_continuous_az
+float64 continuous_az_deg
+bool use_branch
+int32 branch
+---
+bool success
+string state
+string reason
+string state_path
+bool enabled
+bool valid
+float64 raw_az_deg
+float64 modulo_az_deg
+float64 continuous_az_deg
+int32 branch
+float64 period_deg
+float64 drive_min_deg
+float64 drive_max_deg


### PR DESCRIPTION
## Summary

- Add `srv/GetAzUnwrapState.srv`: returns az unwrap runtime state from encoder_readout node
- Add `srv/SetAzUnwrapState.srv`: requests encoder_readout to initialize/override az unwrap state
- Register both in `CMakeLists.txt`

## Motivation

The `necst az-unwrap-state` CLI introduced in the necst ver29 patch needs to route state initialization through the `encoder_readout` ROS node rather than writing a local JSON file directly.  In Docker deployments the control PC's `~/.necst` differs from the encoder node's `state_path`, so direct file writes on the wrong host have no effect.  By serving a ROS service from `encoder_readout`, the JSON is guaranteed to land at the path the node actually reads.

## Related

- necst-telescope/necst#474 (operator console + az unwrap state CLI)
- necst-telescope/necst-msgs#157 (az unwrap status message, base of this branch)
- necst-telescope/necst-msgs#159 (this issue)