### PR TITLE
feat: add request ID to RecordMsg

### DIFF
--- a/msg/RecordMsg.msg
+++ b/msg/RecordMsg.msg
@@ -2,3 +2,4 @@ string name     # Record name.
 bool stop       # If ``true``, current recording will be stopped.
 bool recording  # If ``true``, recording is in progress.
 float64 time
+string request_id  # Identifier shared by a record command and its status response.


### PR DESCRIPTION
## 概要

Recorder commandとstatus responseを対応付けるため、`RecordMsg`に要求識別用の`request_id`を追加します。

## 変更内容

- `RecordMsg.msg`に`string request_id`を追加
- `time`を時刻として保持し、要求識別には専用IDを使えるようにする

このmsg定義は、necst側のRecorder status待機修正（PR #504）から利用します。